### PR TITLE
Generate hazards with an external template

### DIFF
--- a/src/bin/generate-sifis-hazards.rs
+++ b/src/bin/generate-sifis-hazards.rs
@@ -19,6 +19,9 @@ struct Opts {
     #[clap(long, short, value_parser = PossibleValuesParser::new(Templates::all())
         .map(|s| s.parse::<Templates>().unwrap()))]
     template: Templates,
+    /// Path to an external template file
+    #[clap(short, value_hint = clap::ValueHint::DirPath)]
+    external_template: Option<PathBuf>,
     /// Output the generated paths as they are produced
     #[clap(short, long)]
     verbose: bool,
@@ -43,7 +46,18 @@ fn main() {
         .with_writer(std::io::stderr)
         .init();
 
-    HazardsProducer::new()
-        .run(opts.template, opts.ontology_path, opts.output_path)
-        .unwrap();
+    let hazards_producer = HazardsProducer::new();
+    if let Some(external_template) = opts.external_template {
+        hazards_producer
+            .run_with_external_template(
+                opts.ontology_path,
+                opts.output_path,
+                ("external", external_template),
+            )
+            .unwrap();
+    } else {
+        hazards_producer
+            .run(opts.ontology_path, opts.output_path, opts.template)
+            .unwrap();
+    }
 }

--- a/src/toolchain/mod.rs
+++ b/src/toolchain/mod.rs
@@ -1,8 +1,9 @@
+pub mod external;
 pub mod rust;
 
+pub(crate) use external::*;
 pub(crate) use rust::*;
 
-#[macro_export]
 macro_rules! builtin_templates {
     ($root:expr => $(($name:expr, $template:expr)),+) => {
         [
@@ -15,3 +16,16 @@ macro_rules! builtin_templates {
         ]
     }
 }
+
+fn build_source(templates: &[(&str, &str)]) -> minijinja::Source {
+    let mut source = minijinja::Source::new();
+    for (name, src) in templates {
+        source
+            .add_template(*name, *src)
+            .expect("Internal error, built-in template");
+    }
+
+    source
+}
+
+pub(crate) use builtin_templates;


### PR DESCRIPTION
This PR adds the possibility to generate hazards from the ontology using an external template. 

The template should follow the data structure already present within the code to work